### PR TITLE
Keras >= 2.1.5 compatibility

### DIFF
--- a/EEGModels.py
+++ b/EEGModels.py
@@ -39,13 +39,12 @@
 
 from keras.models import Model
 from keras.layers.core import Dense, Activation, Permute, Dropout
-from keras.layers.convolutional import Conv2D, MaxPooling2D, AveragePooling2D
+from keras.layers.convolutional import Conv2D, MaxPooling2D, AveragePooling2D, DepthwiseConv2D
 from keras.layers.convolutional import SeparableConv2D
 from keras.layers.normalization import BatchNormalization
 from keras.layers import SpatialDropout2D
 from keras.regularizers import l1_l2
 from keras.layers import Input, Flatten
-from keras.applications.mobilenet import DepthwiseConv2D
 import keras.backend as K
 from keras.constraints import max_norm
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the Army Research Laboratory (ARL) EEGModels project: A Collection of Co
 # Requirements
 
 - Python (either 2.7 or 3.6)
-- Keras >= 2.1.3
+- Keras >= 2.1.5
 - Tensorflow >= 1.5.0
 - Keras variable 'image_data_format' = "channels_first" in keras.json configuration file
 - Data shape = (trials, kernels, channels, samples), which for the input layer, will be (trials, 1, channels, samples). 


### PR DESCRIPTION
The required Keras version is specified as >=2.1.3, but the module is only compatible with versions 2.1.3 and 2.1.4.

Keras has moved the DepthwiseConv2D class to another module. To be compatible with more recent Keras versions the import path has to be changed.
If you want to keep compatibility with Keras 2.1.3/4 I would suggest a conditional import with a try/catch statement.

Greetings
Felix